### PR TITLE
MIST-368 Parse args with argparse and add tag option

### DIFF
--- a/lochness.yml
+++ b/lochness.yml
@@ -4,12 +4,12 @@
   vars:
 
   roles:
-    - lochness
-    - etcd
-    - dns
-    - agent
-    - tftpd
-    - dhcpd
-    - dhcrelay
-    - confd
-    - enfield
+    - {role: lochness, tags: lochness}
+    - {role: etcd, tags: etcd}
+    - {role: dns, tags: dns}
+    - {role: agent, tags: agent}
+    - {role: tftpd, tags: tftpd}
+    - {role: dhcpd, tags: dhcpd}
+    - {role: dhcrelay, tags: dhcrelay}
+    - {role: confd, tags: confd}
+    - {role: enfield, tags: enfield}

--- a/run
+++ b/run
@@ -9,6 +9,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import argparse
 
 
 def warn(msg, **kwargs):
@@ -20,9 +21,6 @@ def warn(msg, **kwargs):
 
 
 def getID():
-    if len(sys.argv) == 2:
-        return sys.argv[1]
-
     for name in ('/etc/machine_id', '/etc/machine-id', '/sys/class/dmi/id/product_uuid'):
         if os.path.exists(name):
             with open(name) as f:
@@ -46,12 +44,16 @@ def etcdget(url):
     resp = json.load(response)
     return status, resp
 
+parser = argparse.ArgumentParser()
+parser.add_argument('-i', '--id', default=getID())
+parser.add_argument('-t', '--tag', action="append")
+parsedArgs = parser.parse_args()
 
-id = getID()
+id = parsedArgs.id
+tags = parsedArgs.tag
 if id is '':
     print('need an ID!!!')
     exit(-5)
-
 
 config = {'machine_id': id}
 conn = httplib.HTTPConnection('localhost:4001')
@@ -98,6 +100,8 @@ args = ['ansible-playbook',
         '--inventory', adir + '/hosts',
         '--connection=local',
         './lochness.yml']
+if tags:
+    args.extend(['--tags', ','.join(tags)])
 ret = subprocess.call(args)
 if ret == 0:
     shutil.rmtree(adir)


### PR DESCRIPTION
Make id an option flag -i/--id, still defaulting to the machine id read
from file. Add a flag -t/--tag for specifying a role tag to run (may
specify more than one -t for multiple tags). Tag the roles in the
playbook.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mistifyio/lochness-ansible/16)

<!-- Reviewable:end -->
