### PR TITLE
MIST-433 set dhcpd configs to /etc/dhcp

### DIFF
--- a/roles/dhcpd/tasks/enable.yml
+++ b/roles/dhcpd/tasks/enable.yml
@@ -3,15 +3,15 @@
 - queensland: service=dns
   register: dhcpd_nameservers
 
-- file: path=/etc/dhcpd state=directory owner=root mode=0755
+- file: path=/etc/dhcp state=directory owner=root mode=0755
 
-- template: src=dhcpd.conf.j2 dest=/etc/dhcpd/dhcpd.conf owner=root mode=0644
+- template: src=dhcpd.conf.j2 dest=/etc/dhcp/dhcpd.conf owner=root mode=0644
   notify:
   - dhcpd-restart
 
-- file: path=/etc/dhcpd/hypervisors.conf state=touch
+- file: path=/etc/dhcp/hypervisors.conf state=touch
 
-- file: path=/etc/dhcpd/guests.conf state=touch
+- file: path=/etc/dhcp/guests.conf state=touch
 
 - template: src=dhcpd.service.j2 dest=/etc/systemd/system/dhcpd.service owner=root mode=0644
   notify:

--- a/roles/dhcpd/tasks/main.yml
+++ b/roles/dhcpd/tasks/main.yml
@@ -4,7 +4,7 @@
 # populate the dhcpd config. Currently, just using an ansible variable
 # but we may want a simple module for such discoveries
 
-- file: path=/etc/dhcpd state=directory owner=root mode=0755
+- file: path=/etc/dhcp state=directory owner=root mode=0755
 
 - include: enable.yml
   when: dhcpd_enable

--- a/roles/dhcpd/templates/dhcpd.conf.j2
+++ b/roles/dhcpd/templates/dhcpd.conf.j2
@@ -10,5 +10,5 @@ deny unknown-clients;
 
 subnet 0.0.0.0 netmask 0.0.0.0 {}
 
-include "/etc/dhcpd/hypervisors.conf";
-include "/etc/dhcpd/guests.conf";
+include "/etc/dhcp/hypervisors.conf";
+include "/etc/dhcp/guests.conf";

--- a/roles/dhcpd/templates/dhcpd.service.j2
+++ b/roles/dhcpd/templates/dhcpd.service.j2
@@ -4,7 +4,7 @@ Wants=network.target
 After=network.target
 
 [Service]
-ExecStart=/usr/sbin/dhcpd -4 -d -q -f -cf /etc/dhcpd/dhcpd.conf
+ExecStart=/usr/sbin/dhcpd -4 -d -q -f -cf /etc/dhcp/dhcpd.conf
 StandardOutput=inherit
 StandardError=journal
 RestartSec=5s

--- a/roles/dhcpd/templates/guests.toml.j2
+++ b/roles/dhcpd/templates/guests.toml.j2
@@ -1,6 +1,6 @@
 [template]
 src = "guests.conf.tmpl"
-dest = "/etc/dhcpd/guests.conf"
+dest = "/etc/dhcp/guests.conf"
 uid = 0
 mode = "0644"
 prefix = "{{ lochness_etcd_prefix }}"

--- a/roles/dhcpd/templates/hypervisors.toml.j2
+++ b/roles/dhcpd/templates/hypervisors.toml.j2
@@ -1,6 +1,6 @@
 [template]
 src = "hypervisors.conf.tmpl"
-dest = "/etc/dhcpd/hypervisors.conf"
+dest = "/etc/dhcp/hypervisors.conf"
 uid = 0
 mode = "0644"
 prefix = "{{ lochness_etcd_prefix }}"


### PR DESCRIPTION
This is the default when buildroot builds dhcpd and avoids the confusing
situation of having `/etc/dhcp` (stale) and `/etc/dhcpd`.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mistifyio/lochness-ansible/33)

<!-- Reviewable:end -->
