### PR TITLE
lochness/hosts: add just the hostname

### DIFF
--- a/roles/lochness/templates/hosts.j2
+++ b/roles/lochness/templates/hosts.j2
@@ -1,3 +1,3 @@
-127.0.0.1       localhost
-{{ansible_default_ipv4.address}}       {{ansible_hostname}}.nodes.{{lochness_domain}}
-127.0.1.1       Mistify-OS
+127.0.0.1 localhost
+{{ansible_default_ipv4.address}} {{ansible_hostname}}.nodes.{{lochness_domain}} {{ansible_hostname}}
+127.0.1.1 Mistify-OS


### PR DESCRIPTION
Ansible was taking a long time gathering facts before actually running the
playbook. This was happening when ansible was calling python's `socket.getfqdn`
which calls `socket.gethostbyaddr`. `socket.gethostbyaddr` will do a dns lookup
but the dns resolver ignores the line in `/etc/hosts` probably due to the
missing alias. Adding the hostname alias brings ansible fact gaterhing back into
subsecond territory.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mistifyio/lochness-ansible/39)
<!-- Reviewable:end -->
