### PR TITLE
announce as tftp, not tftpd

### DIFF
--- a/roles/tftpd/templates/tftpd-announce.service.j2
+++ b/roles/tftpd/templates/tftpd-announce.service.j2
@@ -5,6 +5,6 @@ After=tftpd.service
 Wants=etcd.service
 
 [Service]
-ExecStart=/usr/sbin/queensland announce tftpd --name={{machine_id}} --port=69
+ExecStart=/usr/sbin/queensland announce tftp --name={{machine_id}} --port=69
 User=nobody
 Restart=always


### PR DESCRIPTION
This trips up the tftp boot because it cannot find tftp.services