### PR TITLE
update options in cbootstrapd to avoid kernel panic

### DIFF
--- a/roles/cbootstrapd/templates/cbootstrapd.service.j2
+++ b/roles/cbootstrapd/templates/cbootstrapd.service.j2
@@ -4,7 +4,7 @@ Wants=network.target
 After=network.target
 
 [Service]
-ExecStart=/usr/sbin/cbootstrapd --base=http://ipxe.services.{{ lochness_domain }}:8888 --options=ramdisk_size=200000\srw\smistify.zfs=auto\szfs=auto
+ExecStart=/usr/sbin/cbootstrapd --base=http://ipxe.services.{{ lochness_domain }}:8888 --options=init=/init\sramdisk_size=300000\sroot=/dev/ram0\srw\sintel_idle.max_cstate=0\svga=794\smistify.zfs=auto\szfs=auto
 Restart=always
 
 [Install]


### PR DESCRIPTION
Right now, this gives options that cause a kernel panic (specifically missing root=), however, I suspect this is supposed to match the iso grub options: https://github.com/mistifyio/mistify-os/blob/master/boot/grub_menu.lst